### PR TITLE
Leaf class: bugfix around GetPMTType-macro

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ app/FitVertexLE
 *.swp
 *.o
 .depend
+lib/

--- a/leaf/BQFitter.cc
+++ b/leaf/BQFitter.cc
@@ -13,6 +13,8 @@ double BQFitter::fSTimePDFLimitsQueueNegative = 0;
 double BQFitter::fSTimePDFLimitsQueuePositive = 0;
 BQFitter* BQFitter::myFitter=NULL;
 
+std::mutex mtx;
+
 /************************************************************************************************************************/
 
 void MinuitLikelihood(int& /*nDim*/, double * /*gout*/, double & NLL, double par[], int /*flg*/){

--- a/leaf/BQFitter.cc
+++ b/leaf/BQFitter.cc
@@ -13,7 +13,6 @@ double BQFitter::fSTimePDFLimitsQueueNegative = 0;
 double BQFitter::fSTimePDFLimitsQueuePositive = 0;
 BQFitter* BQFitter::myFitter=NULL;
 
-
 /************************************************************************************************************************/
 
 void MinuitLikelihood(int& /*nDim*/, double * /*gout*/, double & NLL, double par[], int /*flg*/){

--- a/leaf/BQFitter.cc
+++ b/leaf/BQFitter.cc
@@ -13,7 +13,6 @@ double BQFitter::fSTimePDFLimitsQueueNegative = 0;
 double BQFitter::fSTimePDFLimitsQueuePositive = 0;
 BQFitter* BQFitter::myFitter=NULL;
 
-std::mutex mtx;
 
 /************************************************************************************************************************/
 

--- a/leaf/BQFitter.hh
+++ b/leaf/BQFitter.hh
@@ -40,9 +40,9 @@
 #include "TPaletteAxis.h"
 
 // If using a WCSim version without mPMT implementation
-#define WCSIM_single_PMT_type
+//#define WCSIM_single_PMT_type
 // If using a WCSim version with bugged number of PMT implementation
-#define BUG_WCGEO
+//#define BUG_WCGEO
 
 #define VERBOSE 		0
 //#define CHECK_TO_TRUE_VTX
@@ -76,14 +76,14 @@
 #define GetLength(a)		sqrt( (a[0]*a[0]) + (a[1]*a[1]) + (a[2]*a[2]) )
 #define GetScalarProd(a,b)	a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
 
-#define N_THREAD		12
+#define N_THREAD		1//12
 
 #define CNS2CM 			21.58333
 
 // mPMT Info:
 #define mPMT_TOP_ID		19
 
-std::mutex mtx;
+extern std::mutex mtx;
 
 // Likelihood:
 void MinuitLikelihood(int& nDim, double * gout, double & NLL, double par[], int flg);
@@ -96,7 +96,7 @@ void SearchVertex_CallThread(
 			int iStart, int iIte,
 			int nhits,int tolerance,bool likelihood,double lowerLimit, double upperLimit,int directionality);
 
-bool SortOutputVector ( const std::vector<double>& v1, const std::vector<double>& v2 ) { 
+inline bool SortOutputVector ( const std::vector<double>& v1, const std::vector<double>& v2 ) { 
 	return v1[4] < v2[4]; 
 } 
 		

--- a/leaf/BQFitter.hh
+++ b/leaf/BQFitter.hh
@@ -76,14 +76,14 @@
 #define GetLength(a)		sqrt( (a[0]*a[0]) + (a[1]*a[1]) + (a[2]*a[2]) )
 #define GetScalarProd(a,b)	a[0]*b[0] + a[1]*b[1] + a[2]*b[2]
 
-#define N_THREAD		1//12
+#define N_THREAD		12
 
 #define CNS2CM 			21.58333
 
 // mPMT Info:
 #define mPMT_TOP_ID		19
 
-extern std::mutex mtx;
+std::mutex mtx;
 
 // Likelihood:
 void MinuitLikelihood(int& nDim, double * gout, double & NLL, double par[], int flg);

--- a/leaf/BQFitter.hh
+++ b/leaf/BQFitter.hh
@@ -71,7 +71,7 @@
 #define VTX_Z			2
 #define VTX_T			3
 
-#define GetPMTType(x)		x>=mPMT_ID_SHIFT?1:0
+#define GetPMTType(x)		(x>=mPMT_ID_SHIFT?1:0)
 #define GetDistance(a,b)	sqrt( (a[0]-b[0])*(a[0]-b[0]) + (a[1]-b[1])*(a[1]-b[1]) + (a[2]-b[2])*(a[2]-b[2]) )
 #define GetLength(a)		sqrt( (a[0]*a[0]) + (a[1]*a[1]) + (a[2]*a[2]) )
 #define GetScalarProd(a,b)	a[0]*b[0] + a[1]*b[1] + a[2]*b[2]

--- a/leaf/BQFitter.hh
+++ b/leaf/BQFitter.hh
@@ -40,9 +40,9 @@
 #include "TPaletteAxis.h"
 
 // If using a WCSim version without mPMT implementation
-//#define WCSIM_single_PMT_type
+#define WCSIM_single_PMT_type
 // If using a WCSim version with bugged number of PMT implementation
-//#define BUG_WCGEO
+#define BUG_WCGEO
 
 #define VERBOSE 		0
 //#define CHECK_TO_TRUE_VTX

--- a/leaf/GNUmakefile
+++ b/leaf/GNUmakefile
@@ -27,6 +27,9 @@ all: .depend ../lib/libBQFitter.so
 
 # library
 ../lib/libBQFitter.so: BQFitter.o 
+	@if [ ! -d ../lib ]; then \
+		mkdir ../lib; \
+	fi
 
 #$(DICT).o
 	@echo '<< generating ../lib/libBQFitter.so >>'


### PR DESCRIPTION
I found a bug at a macro of "GetPMTType" in BQFitter.hh and fixed.
This causes miss-identification of the PMT type.

In addition,  I could not use the original BQFitter class in my code due to a linker-error.
I added "inline"  keyword and modified a declaration of "mtx"


